### PR TITLE
Fix exit status

### DIFF
--- a/nq-agent.sh
+++ b/nq-agent.sh
@@ -255,4 +255,4 @@ else
 fi
 
 # Finished
-exit 1
+exit 0


### PR DESCRIPTION
The agent exits with status 1 even when no errors occurred. With this change the status is 0 when everything went OK.

<img width="1440" alt="screen shot 2016-03-19 at 1 06 42 pm" src="https://cloud.githubusercontent.com/assets/1188977/13899810/d923e586-edd5-11e5-84ee-319759ec4be3.png">

The screenshot shows the systemd status before and after the patch is applied.
