### PR TITLE
Use a better CDN to speed up script downloads

### DIFF
--- a/nq-install.sh
+++ b/nq-install.sh
@@ -130,7 +130,7 @@ fi
 mkdir -p /etc/nodequery
 
 # Download agent
-echo -e "|   Downloading nq-agent.sh to /etc/nodequery\n|\n|   + $(wget -nv -o /dev/stdout -O /etc/nodequery/nq-agent.sh --no-check-certificate https://raw.github.com/nodequery/nq-agent/master/nq-agent.sh)"
+echo -e "|   Downloading nq-agent.sh to /etc/nodequery\n|\n|   + $(wget -nv -o /dev/stdout -O /etc/nodequery/nq-agent.sh --no-check-certificate https://cdn.jsdelivr.net/gh/nodequery/nq-agent@master/nq-agent.sh)"
 
 if [ -f /etc/nodequery/nq-agent.sh ]
 then


### PR DESCRIPTION
GitHub download speed is terrible in some countries or regions, so use CDN acceleration service provided by jsDelivr to get a better experience.